### PR TITLE
Updated HttpHelper to make StreamsCharts work again

### DIFF
--- a/TwitchUnjail.Core/Utilities/HttpHelper.cs
+++ b/TwitchUnjail.Core/Utilities/HttpHelper.cs
@@ -14,7 +14,7 @@ namespace TwitchUnjail.Core.Utilities {
             try {
                 using var client = new HttpClient();
                 client.DefaultRequestHeaders.Add("User-Agent", UserAgent);
-                //client.DefaultRequestHeaders.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
+                client.DefaultRequestHeaders.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
                 var response = await client.GetAsync(url);
                 response.EnsureSuccessStatusCode();
                 return true;

--- a/TwitchUnjail.Core/Utilities/HttpHelper.cs
+++ b/TwitchUnjail.Core/Utilities/HttpHelper.cs
@@ -8,13 +8,13 @@ namespace TwitchUnjail.Core.Utilities {
     public static class HttpHelper {
 
         public const string DomainsUrl = "https://raw.githubusercontent.com/TwitchRecover/TwitchRecover/main/domains.txt";
-        public const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.36 Safari/537.36";
+        public const string UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/108.0.5359.112 Mobile/15E148 Safari/604.1";
 
         public static async Task<bool> IsUrlReachable(string url) {
             try {
                 using var client = new HttpClient();
                 client.DefaultRequestHeaders.Add("User-Agent", UserAgent);
-                client.DefaultRequestHeaders.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
+                //client.DefaultRequestHeaders.Add("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
                 var response = await client.GetAsync(url);
                 response.EnsureSuccessStatusCode();
                 return true;


### PR DESCRIPTION
The iPhone UserAgent seems to make StreamsCharts much happier. Client ID doesn't seem necessary either.